### PR TITLE
Add FuseSoC support and Github CI actions

### DIFF
--- a/.github/workflows/fusesoc.yml
+++ b/.github/workflows/fusesoc.yml
@@ -1,0 +1,33 @@
+name: run-fusesoc-targets
+on: [push]
+
+jobs:
+  build-openlane-sky130:
+    runs-on: ubuntu-latest
+    env:
+      REPO : qspiflash
+      VLNV : zipcpu::qspiflash
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: qspiflash
+      - run: echo "EDALIZE_LAUNCHER=el_docker" >> $GITHUB_ENV
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130 $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : qspiflash
+      VLNV : zipcpu::qspiflash
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: qspiflash
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint $VLNV

--- a/data/sky130.tcl
+++ b/data/sky130.tcl
@@ -1,0 +1,6 @@
+set ::env(CLOCK_PORT) "i_clk"
+set ::env(CLOCK_NET) $::env(CLOCK_PORT)
+set ::env(CLOCK_PERIOD) "18.86"
+set ::env(FP_CORE_UTIL) 40
+set ::env(SYNTH_MAX_FANOUT) 6
+set ::env(PL_TARGET_DENSITY) [ expr ($::env(FP_CORE_UTIL)+5) / 100.0 ]

--- a/qspiflash.core
+++ b/qspiflash.core
@@ -1,0 +1,28 @@
+CAPI=2:
+
+name : zipcpu::qspiflash:0
+
+filesets:
+  rtl:
+    files:
+      - rtl/llqspi.v
+      - rtl/wbqspiflash.v
+    file_type : verilogSource
+  sky130:
+    files: [data/sky130.tcl : {file_type : tclSource}]
+
+targets:
+  default:
+    filesets: [rtl]
+
+  lint:
+    default_tool : verilator
+    filesets : [rtl]
+    tools:
+      verilator: {mode: lint-only}
+    toplevel: wbqspiflash
+
+  sky130:
+    default_tool : openlane
+    filesets: [rtl, sky130]
+    toplevel : wbqspiflash


### PR DESCRIPTION
This adds a core description file for the qspiflash core that exposes targets for linting and for building a GDSII using OpenLANE. All targets are also implemented as Github actions so that they get run on every push to the repo.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register qspiflash as a library in the workspace
fusesoc library add qspiflash /path/to/qspiflash
 #...if repo is available locally or...
fusesoc library add qspiflash https://github.com/zipcpu/qspiflash
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint zipcpu::qspiflash
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130 zipcpu::qspiflash
 #List all targets
fusesoc core show zipcpu::qspiflash